### PR TITLE
Update library 20230428 with enable compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ android {
 
     buildFeatures {
         dataBinding true
+        compose true
     }
 
     buildTypes {
@@ -40,6 +41,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.3"
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -51,6 +55,8 @@ android {
 
 dependencies {
 
+    // preview に問題があるので 1.10.0 に上げることは出来ない
+    // https://stackoverflow.com/questions/75937541/jetpack-compose-preview-render-problem-with-java-lang-classnotfoundexception-an
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
@@ -59,22 +65,35 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
+    // jetpack compose bom
+    implementation platform('androidx.compose:compose-bom:2023.03.00')
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.material:material-icons-extended"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation 'androidx.compose.material3:material3'
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
+    implementation "androidx.compose.runtime:runtime-livedata"
+    // jetpack compose
+    implementation 'androidx.activity:activity-compose:1.7.1'
+
     // for test
-    testImplementation 'org.robolectric:robolectric:4.9'
+    testImplementation 'org.robolectric:robolectric:4.10'
     testImplementation "androidx.test:core:1.5.0"
     testImplementation "androidx.test:core-ktx:1.5.0"
     testImplementation "androidx.test.ext:junit:1.1.5"
     testImplementation "androidx.test.ext:junit-ktx:1.1.5"
     testImplementation("androidx.arch.core:core-testing:2.2.0")
-    testImplementation "io.mockk:mockk:1.13.3"
-    testImplementation "org.mockito:mockito-core:4.9.0"
+    testImplementation "io.mockk:mockk:1.13.5"
+    testImplementation "org.mockito:mockito-core:5.3.0"
 
     // jet pack
-    implementation "androidx.fragment:fragment-ktx:1.5.5"
-    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.fragment:fragment-ktx:1.5.7"
+    implementation "androidx.recyclerview:recyclerview:1.3.0"
 
     // androidx.lifecycle
-    def lifecycle_version = "2.5.1"
+    def lifecycle_version = "2.6.1"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     //noinspection LifecycleAnnotationProcessorWithJava8
@@ -82,7 +101,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
 
     // room
-    def room_version = "2.5.0"
+    def room_version = "2.5.1"
     implementation("androidx.room:room-runtime:$room_version")
     kapt("androidx.room:room-compiler:$room_version")
     implementation("androidx.room:room-ktx:$room_version")
@@ -97,7 +116,7 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp_version"
 
     // glide
-    def glide_version = "4.12.0"
+    def glide_version = "4.15.1"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
     implementation "com.github.bumptech.glide:annotations:$glide_version"
@@ -121,16 +140,16 @@ dependencies {
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit2_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit2_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit2_version"
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0'
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0'
 
     // gson
-    implementation "com.google.code.gson:gson:2.9.0"
+    implementation "com.google.code.gson:gson:2.10.1"
 
     // moshi
     implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
 
     // serialization
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
 
     // timber
     implementation "com.jakewharton.timber:timber:5.0.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,9 +55,7 @@ android {
 
 dependencies {
 
-    // preview に問題があるので 1.10.0 に上げることは出来ない
-    // https://stackoverflow.com/questions/75937541/jetpack-compose-preview-render-problem-with-java-lang-classnotfoundexception-an
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
@@ -77,6 +75,8 @@ dependencies {
     implementation "androidx.compose.runtime:runtime-livedata"
     // jetpack compose
     implementation 'androidx.activity:activity-compose:1.7.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
 
     // for test
     testImplementation 'org.robolectric:robolectric:4.10'

--- a/app/src/main/java/us/mitene/practicalexam/ui/theme/Color.kt
+++ b/app/src/main/java/us/mitene/practicalexam/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package us.mitene.practicalexam.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)

--- a/app/src/main/java/us/mitene/practicalexam/ui/theme/Theme.kt
+++ b/app/src/main/java/us/mitene/practicalexam/ui/theme/Theme.kt
@@ -1,0 +1,70 @@
+package us.mitene.practicalexam.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+
+    /* Other default colors to override
+    background = Color(0xFFFFFBFE),
+    surface = Color(0xFFFFFBFE),
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color(0xFF1C1B1F),
+    onSurface = Color(0xFF1C1B1F),
+    */
+)
+
+@Composable
+fun PracticalexamTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android 12+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/us/mitene/practicalexam/ui/theme/Theme.kt
+++ b/app/src/main/java/us/mitene/practicalexam/ui/theme/Theme.kt
@@ -38,7 +38,7 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun PracticalexamTheme(
+fun PracticalExamTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,

--- a/app/src/main/java/us/mitene/practicalexam/ui/theme/Type.kt
+++ b/app/src/main/java/us/mitene/practicalexam/ui/theme/Type.kt
@@ -1,0 +1,34 @@
+package us.mitene.practicalexam.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+    /* Other default text styles to override
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    */
+)

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'


### PR DESCRIPTION
## 概要
* jetpack compose 関連を追加
  * 複数ライブラリ
  * theme 一式 (Compose の新規プロジェクトで作成されるファイル)
* その他ライブラリアップデート

## 相談

AGP 8.0 にあげちゃってもいいですかね？


----------
動作確認は [check-update](https://github.com/mitene/practical-exam/tree/check-update) ブランチに切り替えて確認できます。

* 通常実装と compose 実装での動作確認するためのブランチになります。
* MainActivity で各実装への導線が表示されます
* リストで mixi-inc のリポジトリ一覧がでます
* 主にライブラリの動作確認用の実装なので構成などは雑です
