### PR TITLE
Update library 20231010

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -35,8 +35,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CONTINUATION_INDENT_IN_SUPERTYPE_LISTS" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.0"
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "us.mitene.practicalexam"
         minSdkVersion 25
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -55,9 +54,9 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.10.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
@@ -74,26 +73,26 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-test-manifest"
     implementation "androidx.compose.runtime:runtime-livedata"
     // jetpack compose
-    implementation 'androidx.activity:activity-compose:1.7.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
+    implementation 'androidx.activity:activity-compose:1.8.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
 
     // for test
-    testImplementation 'org.robolectric:robolectric:4.10'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
     testImplementation "androidx.test:core:1.5.0"
     testImplementation "androidx.test:core-ktx:1.5.0"
     testImplementation "androidx.test.ext:junit:1.1.5"
     testImplementation "androidx.test.ext:junit-ktx:1.1.5"
     testImplementation("androidx.arch.core:core-testing:2.2.0")
-    testImplementation "io.mockk:mockk:1.13.5"
-    testImplementation "org.mockito:mockito-core:5.3.0"
+    testImplementation "io.mockk:mockk:1.13.8"
+    testImplementation "org.mockito:mockito-core:5.5.0"
 
     // jet pack
-    implementation "androidx.fragment:fragment-ktx:1.5.7"
-    implementation "androidx.recyclerview:recyclerview:1.3.0"
+    implementation "androidx.fragment:fragment-ktx:1.6.1"
+    implementation "androidx.recyclerview:recyclerview:1.3.1"
 
     // androidx.lifecycle
-    def lifecycle_version = "2.6.1"
+    def lifecycle_version = "2.6.2"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     //noinspection LifecycleAnnotationProcessorWithJava8
@@ -101,9 +100,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
 
     // room
-    def room_version = "2.5.1"
+    def room_version = "2.5.2"
     implementation("androidx.room:room-runtime:$room_version")
-    kapt("androidx.room:room-compiler:$room_version")
+    kapt "androidx.room:room-compiler:$room_version"
     implementation("androidx.room:room-ktx:$room_version")
     implementation("androidx.room:room-rxjava2:$room_version")
     implementation("androidx.room:room-rxjava3:$room_version")
@@ -123,7 +122,7 @@ dependencies {
     kapt "com.github.bumptech.glide:compiler:$glide_version"
 
     // coroutine
-    def coroutine_version = "1.6.4"
+    def coroutine_version = "1.7.3"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutine_version"
@@ -149,18 +148,18 @@ dependencies {
     implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
 
     // serialization
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
 
     // timber
     implementation "com.jakewharton.timber:timber:5.0.1"
 
     // DI : dagger
-    implementation 'com.google.dagger:dagger:2.44.2'
-    kapt 'com.google.dagger:dagger-compiler:2.44.2'
+    implementation 'com.google.dagger:dagger:2.48'
+    kapt 'com.google.dagger:dagger-compiler:2.48'
 
     // DI : hilt
-    implementation 'com.google.dagger:hilt-android:2.44.2'
-    kapt 'com.google.dagger:hilt-compiler:2.44.2'
-    testImplementation 'com.google.dagger:hilt-android-testing:2.44.2'
-    kaptTest 'com.google.dagger:hilt-compiler:2.44.2'
+    implementation 'com.google.dagger:hilt-android:2.48'
+    kapt 'com.google.dagger:hilt-compiler:2.48'
+    testImplementation 'com.google.dagger:hilt-android-testing:2.48'
+    kaptTest 'com.google.dagger:hilt-compiler:2.48'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.48'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44.2'


### PR DESCRIPTION
最新にしました。
glide と room で、ksp への以降 warning が出ていますが、一旦スルー
簡易動作は `check-update` ブランチで確認できます

## MEMO
* compose を最新の 1.5.3 しようとしたが、ビルドエラーになった
* 少し調べたら room が kotlin 1.9.x 非対応のため諦めた
  * stack over flow : https://stackoverflow.com/a/76945761
  * issue tracker : https://issuetracker.google.com/issues/236612358

> Room needs to update its kotlinx-metadata-jvm dependency to be able to read Kotlin 1.9+ metadata. Dependency update should come with Room 2.5.3.

アップデートを試みた差分↓

```diff
diff --git a/app/build.gradle b/app/build.gradle
index f6e27c9..0c55dcf 100644
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.3"
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
@@ -64,7 +64,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     // jetpack compose bom
-    implementation platform('androidx.compose:compose-bom:2023.03.00')
+    implementation platform('androidx.compose:compose-bom:2023.10.00')
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.material:material"
     implementation "androidx.compose.material:material-icons-extended"
diff --git a/build.gradle b/build.gradle
index c8f1aa9..196dfc6 100644
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
(END)
```